### PR TITLE
[READY] permalinks

### DIFF
--- a/_posts/2016-02-22-DevOps-engineer.markdown
+++ b/_posts/2016-02-22-DevOps-engineer.markdown
@@ -2,10 +2,11 @@
 layout: post
 title:  "DevOps Engineer (nl)"
 date:   2016-02-22 9:00:00
-categories: 
+categories:
 redirect_from:
   - devops/2015/09/16/DevOps-engineer.html
   - /2016/02/22/DevOps-engineer.html
+permalink: devops-engineer
 ---
 **Voor de uitbreiding van ons team zijn wij op zoek naar een DevOps engineer**.
 

--- a/_posts/2016-02-22-business-developer.markdown
+++ b/_posts/2016-02-22-business-developer.markdown
@@ -6,6 +6,7 @@ categories:
 redirect_from:
   - 2016/01/08/business-developer.html
   - /2016/02/22/business-developer.html
+permalink: business-developer
 ---
 Du möchtest Freiheiten, tiefe Einblicke und viel Verantwortung? Du möchtest dein Können und deine Talente unter Beweis stellen und in einem großartigen, deutsch-niederländischen Team arbeiten?
 

--- a/_posts/2016-02-22-consultant.markdown
+++ b/_posts/2016-02-22-consultant.markdown
@@ -6,6 +6,7 @@ categories:
 redirect_from:
   - 2016/01/08/consultant.html
   - /2016/02/22/consultant.html
+permalink: consultant
 ---
 Du möchtest Freiheiten, tiefe Einblicke und viel Verantwortung? Du möchtest dein Können und deine Talente unter Beweis stellen und in einem großartigen, deutsch-niederländischen Team arbeiten?
 

--- a/_posts/2016-02-22-front-end-developer.markdown
+++ b/_posts/2016-02-22-front-end-developer.markdown
@@ -6,6 +6,7 @@ categories:
 redirect_from:
   - /2015/08/19/front-end-developer.html
   - /2016/02/22/front-end-developers.html
+permalink: front-end-developer
 ---
 **Voor de uitbreiding van ons team zijn wij op zoek naar front-end developers**. Voor ons Learning Management System CAPP (200.000+ gebruikers in Nederland) ontwikkelen we een nieuwe client in _Ember.js_.
 Wij zoeken daarom naar ervaren front-enders met gevoel voor UX. Daarnaast werken we aan een nieuw product, [LearningSpaces](http://www.learningspaces.io) (www.learningspaces.io) - ook in Ember, maar met een _Ruby on Rails_ back-end.

--- a/_posts/2016-02-22-software-developer.markdown
+++ b/_posts/2016-02-22-software-developer.markdown
@@ -6,6 +6,7 @@ categories:
 redirect_from:
   - 2016/01/08/software-developer.html
   - /2016/02/22/software-developer.html
+permalink: software-developer
 ---
 Du möchtest Freiheiten, tiefe Einblicke und viel Verantwortung? Du möchtest dein Können und deine Talente unter Beweis stellen und in einem großartigen, deutsch-niederländischen Team arbeiten?
 

--- a/_posts/2016-03-08-rails-developer.markdown
+++ b/_posts/2016-03-08-rails-developer.markdown
@@ -3,6 +3,10 @@ layout: post
 title:  "Rails Developer"
 date:   2016-03-07 14:22:53
 categories:
+redirect_from:
+  - 2016/03/07/rails-developer.html
+  - /2016/03/07/rails-developer.html
+permalink: rails-developer
 ---
 
 Voor de uitbreiding van ons team zijn wij op zoek naar Ruby on Rails developers. We zijn sinds september 2014 bezig met een nieuwe product LearningSpaces ([www.learningspaces.io](www.learningspaces.io)). Dat we graag verder ontwikkelen en waar we backend developers voor zoeken. LearningSpaces wordt gemaakt in Ruby on Rails met een Ember front-end.


### PR DESCRIPTION
Add permalinks to frontmatters. This cleans up the URL's of the vacancies. 

AFAK: needs the redirect on the rails-dev vacancy to work properly. 
